### PR TITLE
[FEAT] 최근 검색 경로 API 구현

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -13,6 +13,8 @@ expressWs(app);
 
 const port = config.port;
 
+// favicon 무시
+app.use("/favicon.ico", () => {});
 app.use(sessionMiddleware);
 app.use(corsMiddleware);
 app.use(express.urlencoded({ extended: true }));

--- a/server/src/controllers/carsController.js
+++ b/server/src/controllers/carsController.js
@@ -1,4 +1,4 @@
-import { getRouteAndDirection, getRouteDetail } from "../services/routeService.js";
+import { saveRecentRoute, getRouteAndDirection, getRouteDetail } from "../services/routeService.js";
 import { calculateRanking, calculateChanceByCount, determineHighTraffic, findHighCars } from "../services/carService.js";
 
 // 추천 호차 랭킹
@@ -8,6 +8,8 @@ async function rank(req, res) {
     const { route, direction } = await getRouteAndDirection(startStation, endStation);
     const routeDetail = await getRouteDetail(route, direction);
     const carRank = calculateRanking(routeDetail);
+
+    await saveRecentRoute(req, startStation, endStation);
 
     res.send(carRank);
   } catch (error) {
@@ -21,8 +23,8 @@ async function info(req, res) {
   const { route, direction } = await getRouteAndDirection(startStation, endStation);
   const routeDetail = await getRouteDetail(route, direction);
   const chanceByRoute = calculateChanceByCount(routeDetail, carNumber);
-	const trafficArr = await determineHighTraffic(routeDetail);
-	const highCarArr = findHighCars(routeDetail);
+  const trafficArr = await determineHighTraffic(routeDetail);
+  const highCarArr = findHighCars(routeDetail);
 
   const result = [];
 

--- a/server/src/controllers/stationsController.js
+++ b/server/src/controllers/stationsController.js
@@ -7,4 +7,12 @@ function getStations(req, res) {
   res.sendFile(path.join(__dirname, "src", "data", "stationCodes.json"));
 }
 
-export default { getStations };
+function recentRoutes(req, res) {
+  if (!req.session.recentRoutes) {
+    res.status(404).send("Recent routes not found");
+  } else {
+    res.json(req.session.recentRoutes);
+  }
+}
+
+export default { getStations, recentRoutes };

--- a/server/src/routes/stationsRoutes.js
+++ b/server/src/routes/stationsRoutes.js
@@ -4,5 +4,6 @@ import stationsController from "../controllers/stationsController.js";
 const router = express.Router();
 
 router.get("/", stationsController.getStations);
+router.get("/recent-routes", stationsController.recentRoutes);
 
 export default router;

--- a/server/src/services/routeService.js
+++ b/server/src/services/routeService.js
@@ -2,6 +2,19 @@ import { getStations } from "./stationService.js";
 import { getTime, truncateToNearestTen } from "../services/timeService.js";
 import { getConnection, executeQuery, endConnection } from "../services/databaseService.js";
 
+// 최근 경로 저장하는 함수
+async function saveRecentRoute(req, startStation, endStation) {
+  if (!req.session.recentRoutes) {
+    req.session.recentRoutes = [];
+  }
+
+  req.session.recentRoutes.unshift({ startStation, endStation });
+
+  if (req.session.recentRoutes.length > 3) {
+    req.session.recentRoutes.pop();
+  }
+}
+
 // 출발/도착역에 따른 경로, 내외선 방향 계산 함수
 async function getRouteAndDirection(startStation, endStation) {
   const stations = await getStations();
@@ -77,4 +90,4 @@ async function getRouteDetail(route, direction) {
   return routeInfo;
 }
 
-export { getRouteAndDirection, getRouteDetail };
+export { saveRecentRoute, getRouteAndDirection, getRouteDetail };


### PR DESCRIPTION
- 최근 검색된 3개의 경로
   - 최신순(최근 검색한 경로가 index 0: 맨 앞)
    - 응답 예시
        [
          { startStation: '시청', endStation: '신도림' },
          { startStation: '잠실나루', endStation: '종합운동장' },
          { startStation: '홍대입구', endStation: '을지로입구' },
        ]

- 전체적인 리팩토링 필요해보임...
   - station, car, route 불명확함...