### PR TITLE
[FEAT] 추천 호차 랭킹 및 경로까지 역 별 혼잡도 정보 응답값 수정 

### DIFF
--- a/server/src/controllers/carsController.js
+++ b/server/src/controllers/carsController.js
@@ -1,5 +1,5 @@
 import { saveRecentRoute, getRouteAndDirection, getRouteDetail } from "../services/routeService.js";
-import { calculateRanking, calculateChanceByCount, determineHighTraffic, findHighCars } from "../services/carService.js";
+import { calculateRanking, calculateChanceByRoute, determineHighTraffic, findHighCars } from "../services/carService.js";
 
 // 추천 호차 랭킹
 async function rank(req, res) {
@@ -8,7 +8,6 @@ async function rank(req, res) {
     const { route, direction } = await getRouteAndDirection(startStation, endStation);
     const routeDetail = await getRouteDetail(route, direction);
     const carRank = calculateRanking(routeDetail);
-
     await saveRecentRoute(req, startStation, endStation);
 
     res.send(carRank);
@@ -22,7 +21,7 @@ async function info(req, res) {
   const { startStation, endStation, carNumber } = req.query;
   const { route, direction } = await getRouteAndDirection(startStation, endStation);
   const routeDetail = await getRouteDetail(route, direction);
-  const chanceByRoute = calculateChanceByCount(routeDetail, carNumber);
+  const chanceByRoute = calculateChanceByRoute(routeDetail, carNumber);
   const trafficArr = await determineHighTraffic(routeDetail);
   const highCarArr = findHighCars(routeDetail);
 


### PR DESCRIPTION
- **추천 호차 랭킹 응답값 isSeatAvailable: 예측 인원 -> 퍼센트**
- **경로까지 역 별 혼잡도 응답값 chance: 낮음,중간,높음(0,1,2) -> 퍼센트**

- findMinCountByCar() -> findBestCountByCar()
   - 출발역에서 54이하면 최솟값보다 우선순위 높도록 코드 수정
   - 이 경우 고려할 때 minCount라는 변수명, 함수명이 혼돈되어 BestCount로 변경