### PR TITLE
[FEAT] 게시글 상세페이지 API 응답값에 댓글 수 추가 & [FIX] 댓글 목록 응답값 중 isLiked가 0인 문제 해결

### DIFF
--- a/server/src/controllers/commentsController.js
+++ b/server/src/controllers/commentsController.js
@@ -30,8 +30,8 @@ async function getCommentList(req, res) {
     //달린 댓글이 없는 경우
     if (!totalpageCount) {
       res.status(200).json({
-        "totalpageCount": 1,
-        "data": []
+        totalpageCount: 1,
+        data: [],
       });
       return;
     }
@@ -49,7 +49,7 @@ async function getCommentList(req, res) {
       const creationDate = row.creation_date;
       const likeCount = row.like_count;
       const isAuthor = row.user_id === req.sessionID ? 1 : 0;
-      const isLiked = req.session.commentLiked.indexOf(row.id) !== -1 ? 1 : 0;
+      const isLiked = req.session.commentLiked.indexOf(`${id}`) !== -1 ? 1 : 0;
 
       data.push({ id, userId, username, content, creationDate, likeCount, isAuthor, isLiked });
     });


### PR DESCRIPTION
- 게시글 상세페이지 API 응답값에 댓글 수 추가
   - "commentCount"에 댓글 수 담아서 보냄

- 댓글 목록 응답값 중 isLiked가 0인 문제 해결
   - indexOf(`${id}`) : id를 String 타입으로 형변환